### PR TITLE
Add redirects for Background Sync specs

### DIFF
--- a/BackgroundSync/spec/PeriodicBackgroundSync-index.html
+++ b/BackgroundSync/spec/PeriodicBackgroundSync-index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<script>
+    let currentHash = window.location.hash;
+    let newLocation = "https://wicg.github.io/background-sync/spec/PeriodicBackgroundSync-index.html" + currentHash;
+    window.location = newLocation;
+</script>

--- a/BackgroundSync/spec/index.html
+++ b/BackgroundSync/spec/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<script>
+    let currentHash = window.location.hash;
+    let newLocation = "https://wicg.github.io/background-sync/spec/" + currentHash;
+    window.location = newLocation;
+</script>


### PR DESCRIPTION
Repo name changed from BackgroundSync to background-sync:
https://github.com/WICG/background-sync/pull/177

Adding redirect rules for the drafts accordingly.

@jakearchibald, FYI.