### PR TITLE
Add redirect for conversion-measurement-api

### DIFF
--- a/conversion-measurement-api/index.html
+++ b/conversion-measurement-api/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+  const { hash } = window.location;
+  window.location = `https://wicg.github.io/attribution-reporting-api/${hash}`;
+</script>


### PR DESCRIPTION
Spec is still developed in WICG, but the repo name was recently changed.