### PR TITLE
Add URLPattern

### DIFF
--- a/urlpattern/index.html
+++ b/urlpattern/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<script>
+    let currentHash = window.location.hash;
+    let newLocation = "https://urlpattern.spec.whatwg.org/" + currentHash;
+    window.location = newLocation;
+</script>


### PR DESCRIPTION
The URLPattern API has graduated from WICG and now it's under the WHATWG. The repository was also transferred into https://github.com/whatwg/urlpattern, which broke the page hosted in https://wicg.github.io/urlpattern/ and now it's 404.

After the transition, https://urlpattern.spec.whatwg.org/ is the correct URL and we'd like to imitate the redirect from the old URL to the new one. The new URL is still empty for now but that should be fine because the old page is already 404. It doesn't worse the experience.